### PR TITLE
Milliseconds correctly converted to seconds for timeout error message

### DIFF
--- a/bin/run-local-lambda.js
+++ b/bin/run-local-lambda.js
@@ -134,7 +134,7 @@
 
 	var execute = function(){
 		setTimeout(function(){
-			console.log('The function timed out after ' + settings.timeout + ' seconds');
+			console.log('The function timed out after ' + (settings.timeout / 1000) + ' seconds');
 			process.exit();
 		}, settings.timeout);
 


### PR DESCRIPTION
### Description

Error mesage reported incorrect timeout e.g. `The function timed out after 3000 seconds` (for default value) because tiumeout was not coverted back to seconds.